### PR TITLE
With netlify adapter and headers config

### DIFF
--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -8,6 +8,24 @@ const config: GatsbyConfig = {
   adapter: adapter({
     excludeDatastoreFromEngineFunction: false,
   }),
+  headers: [
+    {
+      source: `/*`,
+      headers: [{ key: `X-EveryResource`, value: `Gets this header`}]
+    },
+    {
+      source: `/`,
+      headers: [{ key: `X-PageName`, value: `Home`}, { key: `Link`, value: `</../../../public/static/logo.png>; rel=preload; as=image`}]
+    },
+    {
+      source: `/test-page`,
+      headers: [{ key: `X-PageName`, value: `Test-Page`}]
+    },
+    {
+      source: `/testpage`,
+      headers: [{ key: `X-PageName`, value: `TestPage`}]
+    }
+  ],
   pathPrefix: process.env.ENABLE_PATH_PREFIX === `true` ? `/blog` : undefined,
   assetPrefix: process.env.ENABLE_ASSET_PREFIX === `true` ? `https://www.cdn.com` : undefined,
   siteMetadata: {

--- a/gatsby-config.ts
+++ b/gatsby-config.ts
@@ -1,13 +1,13 @@
 import type { GatsbyConfig } from "gatsby";
+import adapter from 'gatsby-adapter-netlify';
 
 const config: GatsbyConfig = {
-  // we are not building on NETLIFY so no adapters
-  // will be forced to be used.  If we were building
-  // on NETLIFY, process.env.NETLIFY would be true
-  // and the `gatsby-adapter-netlify` forced in to the build
-  // and `gatsby-plugin-netlify` force removed with no `stock` 
-  // way to opt-out of the adapter and keep the plugin resulting
-  // in different build output.
+  // necessary to explicitly load adapter since we're not building on NETLIFY
+  // where it would be used automatically along with gatsby-plugin-netlify 
+  // begin removed automatically both without any `stock` method of opting out
+  adapter: adapter({
+    excludeDatastoreFromEngineFunction: false,
+  }),
   pathPrefix: process.env.ENABLE_PATH_PREFIX === `true` ? `/blog` : undefined,
   assetPrefix: process.env.ENABLE_ASSET_PREFIX === `true` ? `https://www.cdn.com` : undefined,
   siteMetadata: {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "gatsby": "^5.11.0",
+    "gatsby-adapter-netlify": "^1.0.0",
     "gatsby-plugin-netlify": "^5.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/public/_headers
+++ b/public/_headers
@@ -6,280 +6,329 @@
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-media.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-sandbox-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-ww-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-ww-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/404.html/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/404/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/index/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/retiredpage/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/testpagenew/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/app/*
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-media.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/app-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png/
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /404.html
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /404/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-1a595b41368173a2bab9.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-1a595b41368173a2bab9.js.LICENSE.txt
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-1a595b41368173a2bab9.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /chunk-map.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-404-tsx-70daa1be2219423f7f5e.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-404-tsx-70daa1be2219423f7f5e.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-app-tsx-f3db3491e78f7def5ae9.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-index-tsx-38c0953b50340aa95cae.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-index-tsx-38c0953b50340aa95cae.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js.LICENSE.txt
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /logo.png/
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /retiredpage/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /testpagenew/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack-runtime-54184daee17a8bef6605.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack-runtime-54184daee17a8bef6605.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack.stats.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app/*
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
+  X-PageName: Home
+  Link: </../../../public/static/logo.png>; rel=preload; as=image
 
 # gatsby-adapter-netlify end

--- a/public/_headers
+++ b/public/_headers
@@ -1,65 +1,285 @@
-## Created with gatsby-plugin-netlify
 
-/*
-  X-Frame-Options: DENY
-  X-XSS-Protection: 1; mode=block
-  X-Content-Type-Options: nosniff
-  Referrer-Policy: same-origin
-  X-EveryResource: Gets this header
-  X-TransformedHeader: This is transformed
-/
-  X-PageName: Home
-  Link: </../../../public/static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png>; rel=preload; as=image
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/test-page
-  X-PageName: Test-Page
-  X-TransformedHeader: This is transformed
-/testpage
-  X-PageName: TestPage
-  X-TransformedHeader: This is transformed
-/component---src-pages-404-tsx-70daa1be2219423f7f5e.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-index-tsx-38c0953b50340aa95cae.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/webpack-runtime-54184daee17a8bef6605.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/framework-5e8a38bf990470ba1888.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/app-1a595b41368173a2bab9.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/static/*
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/sw.js
-  Cache-Control: no-cache
-  X-TransformedHeader: This is transformed
-/404/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+# gatsby-adapter-netlify start
+/_gatsby/slices/_gatsby-scripts-1.html
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-media.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-sandbox-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-ww-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-ww-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/404.html/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/404/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/index/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/retiredpage/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/testpagenew/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/app/*
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-media.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/app-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png/
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /404.html
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/app/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/404/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app-1a595b41368173a2bab9.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app-1a595b41368173a2bab9.js.LICENSE.txt
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app-1a595b41368173a2bab9.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/chunk-map.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-404-tsx-70daa1be2219423f7f5e.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-404-tsx-70daa1be2219423f7f5e.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-index-tsx-38c0953b50340aa95cae.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-index-tsx-38c0953b50340aa95cae.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js.LICENSE.txt
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/logo.png/
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /retiredpage/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /testpagenew/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack-runtime-54184daee17a8bef6605.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack-runtime-54184daee17a8bef6605.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack.stats.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app/*
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+
+# gatsby-adapter-netlify end

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,12 +1,15 @@
 
-## Created with gatsby-plugin-netlify
-/testpageold/  /testpagenew/  302
-/permanentpageold/  /permanentpagenew/  301
-/retiredpage/  /  302!
-/forcepageold/  /forcepagenew/  302!
-/conditionspageold/  /conditionspagenew/  302  Language=en,fr  Country=us,ca
-/redirectinbrowserpageold/  /redirectinbrowserpagenew/  302
-/statuscodepageold/  /statuscodepagenew/  303
+# gatsby-adapter-netlify start
+/page-data/app/*  /page-data/app/page-data.json  200
+/https://www.gatsbyjs.org  https://www.netlify.com  301
+/conditionspageold/  /conditionspagenew/  302
+/forcepageold/  /forcepagenew/  302
 /ignoreCasePageOld  /ignorecAsepAgenEw/  302
-https://www.gatsbyjs.org  https://www.netlify.com  301!
-/app/*  /app/  200
+/permanentpageold/  /permanentpagenew/  301
+/redirectinbrowserpageold/  /redirectinbrowserpagenew/  302
+/retiredpage/  /  302
+/statuscodepageold/  /statuscodepagenew/  303
+/testpageold/  /testpagenew/  302
+/app/*  /app/index.html  200
+
+# gatsby-adapter-netlify end

--- a/sanitized_headers
+++ b/sanitized_headers
@@ -6,280 +6,329 @@
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-media.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-sandbox-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-ww-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-ww-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/404.html/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/404/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/index/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/retiredpage/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/testpagenew/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/app/*
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-media.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/app-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png/
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-1a595b41368173a2bab9.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-1a595b41368173a2bab9.js.LICENSE.txt
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-1a595b41368173a2bab9.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /chunk-map.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-404-tsx-70daa1be2219423f7f5e.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-404-tsx-70daa1be2219423f7f5e.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-app-tsx-f3db3491e78f7def5ae9.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-index-tsx-38c0953b50340aa95cae.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-index-tsx-38c0953b50340aa95cae.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js.LICENSE.txt
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /logo.png/
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack-runtime-54184daee17a8bef6605.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack-runtime-54184daee17a8bef6605.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack.stats.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
+  X-PageName: Home
+  Link: </../../../public/static/logo.png>; rel=preload; as=image
 /404/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /404.html
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app/*
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /retiredpage/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /testpagenew/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY  
+  X-EveryResource: Gets this header
 
 # gatsby-adapter-netlify end

--- a/sanitized_headers
+++ b/sanitized_headers
@@ -1,65 +1,285 @@
-## Created with gatsby-plugin-netlify
 
-/*
-  X-Frame-Options: DENY
-  X-XSS-Protection: 1; mode=block
-  X-Content-Type-Options: nosniff
-  Referrer-Policy: same-origin
-  X-EveryResource: Gets this header
-  X-TransformedHeader: This is transformed
-/component---src-pages-404-tsx-70daa1be2219423f7f5e.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-index-tsx-38c0953b50340aa95cae.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/webpack-runtime-54184daee17a8bef6605.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/framework-5e8a38bf990470ba1888.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
+# gatsby-adapter-netlify start
+/_gatsby/slices/_gatsby-scripts-1.html
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-media.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-sandbox-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-ww-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-ww-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/404.html/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/404/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/index/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/retiredpage/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/testpagenew/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/app/*
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-media.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/app-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png/
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /app-1a595b41368173a2bab9.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/static/*
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/sw.js
-  Cache-Control: no-cache
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app-1a595b41368173a2bab9.js.LICENSE.txt
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app-1a595b41368173a2bab9.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/chunk-map.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-404-tsx-70daa1be2219423f7f5e.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-404-tsx-70daa1be2219423f7f5e.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-index-tsx-38c0953b50340aa95cae.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-index-tsx-38c0953b50340aa95cae.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js.LICENSE.txt
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/logo.png/
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack-runtime-54184daee17a8bef6605.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack-runtime-54184daee17a8bef6605.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack.stats.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /
-  X-PageName: Home
-  Link: </../../../public/static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png>; rel=preload; as=image
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /404/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /404.html
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/app/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app/*
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /retiredpage/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/test-page
-  X-PageName: Test-Page
-  X-TransformedHeader: This is transformed
-/testpage
-  X-PageName: TestPage
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /testpagenew/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY  
+
+# gatsby-adapter-netlify end

--- a/sanitized_headers_assetprefix
+++ b/sanitized_headers_assetprefix
@@ -1,67 +1,285 @@
-## Created with gatsby-plugin-netlify
 
-/*
-  X-Frame-Options: DENY
-  X-XSS-Protection: 1; mode=block
-  X-Content-Type-Options: nosniff
-  Referrer-Policy: same-origin
-  X-EveryResource: Gets this header
-  X-TransformedHeader: This is transformed
-/component---src-pages-404-tsx-70daa1be2219423f7f5e.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-index-tsx-38c0953b50340aa95cae.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/webpack-runtime-1b5a430372f1404acffd.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/framework-5e8a38bf990470ba1888.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
+# gatsby-adapter-netlify start
+/_gatsby/slices/_gatsby-scripts-1.html
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-media.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-sandbox-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-ww-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-ww-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/404.html/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/404/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/index/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/retiredpage/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/testpagenew/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/app/*
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-media.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/app-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png/
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /app-d7b571df3a717b981470.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/static/*
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/sw.js
-  Cache-Control: no-cache
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app-d7b571df3a717b981470.js.LICENSE.txt
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app-d7b571df3a717b981470.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/chunk-map.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-404-tsx-70daa1be2219423f7f5e.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-404-tsx-70daa1be2219423f7f5e.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-index-tsx-38c0953b50340aa95cae.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-index-tsx-38c0953b50340aa95cae.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js.LICENSE.txt
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/logo.png/
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack-runtime-1b5a430372f1404acffd.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack-runtime-1b5a430372f1404acffd.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack.stats.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /
-  X-PageName: Home
-  Link: </https://www.cdn.com/blog../../../public/static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png>; rel=preload; as=image
-  X-TransformedHeader: This is transformed
-https://www.cdn.com/blog/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-https://www.cdn.com/blog/404/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-https://www.cdn.com/blog/404.html
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-https://www.cdn.com/blog/app/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-https://www.cdn.com/blog/retiredpage/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/test-page
-  X-PageName: Test-Page
-  X-TransformedHeader: This is transformed
-/testpage
-  X-PageName: TestPage
-  X-TransformedHeader: This is transformed
-https://www.cdn.com/blog/testpagenew/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app/*
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/404/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/404.html
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/retiredpage/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/testpagenew/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+
+# gatsby-adapter-netlify end

--- a/sanitized_headers_assetprefix
+++ b/sanitized_headers_assetprefix
@@ -6,280 +6,329 @@
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-media.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-sandbox-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-ww-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-ww-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/404.html/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/404/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/index/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/retiredpage/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/testpagenew/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/app/*
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-media.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/app-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png/
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-d7b571df3a717b981470.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-d7b571df3a717b981470.js.LICENSE.txt
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-d7b571df3a717b981470.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /chunk-map.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-404-tsx-70daa1be2219423f7f5e.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-404-tsx-70daa1be2219423f7f5e.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-app-tsx-f3db3491e78f7def5ae9.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-index-tsx-38c0953b50340aa95cae.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-index-tsx-38c0953b50340aa95cae.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js.LICENSE.txt
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /logo.png/
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack-runtime-1b5a430372f1404acffd.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack-runtime-1b5a430372f1404acffd.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack.stats.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
+  X-PageName: Home
+  Link: </../../../public/static/logo.png>; rel=preload; as=image
 /app/*
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /404/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /404.html
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /retiredpage/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /testpagenew/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header  
 
 # gatsby-adapter-netlify end

--- a/sanitized_headers_extrapages
+++ b/sanitized_headers_extrapages
@@ -1,365 +1,1485 @@
-## Created with gatsby-plugin-netlify
 
-/*
-  X-Frame-Options: DENY
-  X-XSS-Protection: 1; mode=block
-  X-Content-Type-Options: nosniff
-  Referrer-Policy: same-origin
-  X-EveryResource: Gets this header
-  X-TransformedHeader: This is transformed
-/component---src-pages-404-tsx-70daa1be2219423f7f5e.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-index-tsx-38c0953b50340aa95cae.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/webpack-runtime-54184daee17a8bef6605.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/framework-5e8a38bf990470ba1888.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
+# gatsby-adapter-netlify start
+/_gatsby/slices/_gatsby-scripts-1.html
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-media.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-sandbox-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-ww-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-ww-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/404.html/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/404/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-1/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-10/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-100/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-11/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-12/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-13/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-14/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-15/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-16/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-17/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-18/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-19/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-2/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-20/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-21/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-22/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-23/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-24/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-25/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-26/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-27/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-28/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-29/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-3/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-30/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-31/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-32/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-33/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-34/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-35/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-36/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-37/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-38/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-39/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-4/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-40/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-41/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-42/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-43/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-44/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-45/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-46/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-47/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-48/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-49/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-5/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-50/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-51/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-52/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-53/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-54/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-55/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-56/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-57/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-58/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-59/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-6/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-60/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-61/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-62/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-63/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-64/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-65/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-66/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-67/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-68/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-69/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-7/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-70/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-71/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-72/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-73/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-74/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-75/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-76/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-77/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-78/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-79/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-8/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-80/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-81/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-82/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-83/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-84/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-85/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-86/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-87/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-88/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-89/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-9/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-90/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-91/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-92/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-93/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-94/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-95/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-96/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-97/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-98/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/extra-page-99/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/index/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/retiredpage/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/testpagenew/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/app/*
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-media.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/app-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png/
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /app-1a595b41368173a2bab9.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/static/*
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/sw.js
-  Cache-Control: no-cache
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app-1a595b41368173a2bab9.js.LICENSE.txt
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app-1a595b41368173a2bab9.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/chunk-map.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-404-tsx-70daa1be2219423f7f5e.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-404-tsx-70daa1be2219423f7f5e.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-index-tsx-38c0953b50340aa95cae.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-index-tsx-38c0953b50340aa95cae.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js.LICENSE.txt
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/logo.png/
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack-runtime-54184daee17a8bef6605.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack-runtime-54184daee17a8bef6605.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack.stats.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /
-  X-PageName: Home
-  Link: </../../../public/static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png>; rel=preload; as=image
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /404/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /404.html
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/app/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app/*
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /retiredpage/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/test-page
-  X-PageName: Test-Page
-  X-TransformedHeader: This is transformed
-/testpage
-  X-PageName: TestPage
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /testpagenew/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /extra-page-1/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-2/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-3/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-4/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-5/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-6/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-7/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-8/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-9/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /extra-page-10/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-11/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-12/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-13/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-14/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-15/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-16/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-17/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-18/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-19/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-20/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-21/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-22/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-23/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-24/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-25/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-26/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-27/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-28/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-29/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-30/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-31/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-32/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-33/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-34/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-35/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-36/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-37/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-38/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-39/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-40/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-41/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-42/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-43/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-44/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-45/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-46/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-47/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-48/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-49/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-50/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-51/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-52/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-53/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-54/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-55/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-56/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-57/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-58/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-59/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-60/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-61/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-62/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-63/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-64/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-65/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-66/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-67/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-68/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-69/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-70/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-71/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-72/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-73/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-74/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-75/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-76/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-77/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-78/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-79/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-80/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-81/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-82/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-83/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-84/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-85/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-86/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-87/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-88/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-89/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-90/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-91/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-92/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-93/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-94/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-95/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-96/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-97/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-98/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/extra-page-99/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /extra-page-100/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-11/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-12/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-13/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-14/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-15/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-16/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-17/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-18/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-19/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-2/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-20/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-21/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-22/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-23/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-24/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-25/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-26/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-27/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-28/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-29/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-3/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-30/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-31/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-32/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-33/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-34/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-35/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-36/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-37/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-38/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-39/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-4/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-40/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-41/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-42/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-43/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-44/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-45/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-46/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-47/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-48/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-49/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-5/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-50/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-51/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-52/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-53/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-54/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-55/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-56/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-57/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-58/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-59/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-6/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-60/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-61/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-62/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-63/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-64/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-65/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-66/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-67/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-68/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-69/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-7/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-70/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-71/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-72/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-73/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-74/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-75/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-76/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-77/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-78/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-79/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-8/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-80/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-81/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-82/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-83/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-84/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-85/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-86/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-87/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-88/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-89/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-9/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-90/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-91/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-92/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-93/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-94/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-95/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-96/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-97/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-98/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/extra-page-99/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+
+# gatsby-adapter-netlify end

--- a/sanitized_headers_extrapages
+++ b/sanitized_headers_extrapages
@@ -6,1480 +6,1729 @@
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-media.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-sandbox-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-ww-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-ww-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/404.html/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/404/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-1/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-10/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-100/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-11/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-12/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-13/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-14/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-15/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-16/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-17/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-18/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-19/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-2/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-20/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-21/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-22/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-23/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-24/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-25/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-26/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-27/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-28/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-29/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-3/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-30/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-31/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-32/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-33/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-34/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-35/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-36/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-37/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-38/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-39/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-4/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-40/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-41/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-42/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-43/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-44/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-45/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-46/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-47/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-48/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-49/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-5/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-50/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-51/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-52/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-53/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-54/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-55/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-56/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-57/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-58/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-59/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-6/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-60/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-61/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-62/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-63/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-64/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-65/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-66/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-67/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-68/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-69/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-7/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-70/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-71/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-72/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-73/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-74/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-75/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-76/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-77/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-78/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-79/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-8/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-80/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-81/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-82/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-83/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-84/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-85/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-86/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-87/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-88/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-89/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-9/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-90/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-91/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-92/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-93/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-94/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-95/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-96/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-97/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-98/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/extra-page-99/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/index/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/retiredpage/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/testpagenew/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/app/*
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-media.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/app-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png/
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-1a595b41368173a2bab9.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-1a595b41368173a2bab9.js.LICENSE.txt
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-1a595b41368173a2bab9.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /chunk-map.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-404-tsx-70daa1be2219423f7f5e.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-404-tsx-70daa1be2219423f7f5e.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-app-tsx-f3db3491e78f7def5ae9.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-index-tsx-38c0953b50340aa95cae.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-index-tsx-38c0953b50340aa95cae.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js.LICENSE.txt
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /logo.png/
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack-runtime-54184daee17a8bef6605.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack-runtime-54184daee17a8bef6605.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack.stats.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
+  X-PageName: Home
+  Link: </../../../public/static/logo.png>; rel=preload; as=image
 /404/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /404.html
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app/*
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /retiredpage/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /testpagenew/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-1/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-10/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-100/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-11/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-12/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-13/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-14/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-15/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-16/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-17/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-18/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-19/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-2/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-20/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-21/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-22/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-23/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-24/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-25/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-26/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-27/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-28/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-29/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-3/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-30/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-31/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-32/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-33/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-34/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-35/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-36/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-37/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-38/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-39/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-4/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-40/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-41/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-42/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-43/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-44/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-45/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-46/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-47/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-48/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-49/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-5/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-50/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-51/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-52/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-53/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-54/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-55/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-56/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-57/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-58/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-59/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-6/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-60/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-61/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-62/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-63/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-64/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-65/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-66/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-67/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-68/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-69/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-7/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-70/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-71/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-72/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-73/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-74/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-75/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-76/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-77/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-78/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-79/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-8/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-80/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-81/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-82/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-83/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-84/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-85/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-86/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-87/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-88/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-89/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-9/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-90/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-91/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-92/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-93/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-94/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-95/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-96/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-97/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-98/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /extra-page-99/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 
 # gatsby-adapter-netlify end

--- a/sanitized_headers_pathprefix
+++ b/sanitized_headers_pathprefix
@@ -6,280 +6,329 @@
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-media.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-sandbox-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-ww-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown-ww-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/debug/partytown.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/404.html/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/404/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/index/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/retiredpage/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/testpagenew/page-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/app/*
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-atomics.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-media.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown-sw.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /~partytown/partytown.js
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /page-data/app-data.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png/
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-c843bdf0e6663ec98280.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-c843bdf0e6663ec98280.js.LICENSE.txt
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app-c843bdf0e6663ec98280.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /chunk-map.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-404-tsx-70daa1be2219423f7f5e.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-404-tsx-70daa1be2219423f7f5e.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-app-tsx-f3db3491e78f7def5ae9.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-index-tsx-38c0953b50340aa95cae.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-index-tsx-38c0953b50340aa95cae.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js.LICENSE.txt
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /framework-5e8a38bf990470ba1888.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /logo.png/
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack-runtime-c41fe3b9106585da6a0d.js
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack-runtime-c41fe3b9106585da6a0d.js.map
   cache-control: public, max-age=31536000, immutable
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /webpack.stats.json
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
+  X-PageName: Home
+  Link: </../../../public/static/logo.png>; rel=preload; as=image
 /404/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /404.html
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /app/*
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /retiredpage/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 /testpagenew/
   cache-control: public, max-age=0, must-revalidate
   x-xss-protection: 1; mode=block
   x-content-type-options: nosniff
   referrer-policy: same-origin
   x-frame-options: DENY
+  X-EveryResource: Gets this header
 
 # gatsby-adapter-netlify end

--- a/sanitized_headers_pathprefix
+++ b/sanitized_headers_pathprefix
@@ -1,67 +1,285 @@
-## Created with gatsby-plugin-netlify
 
-/*
-  X-Frame-Options: DENY
-  X-XSS-Protection: 1; mode=block
-  X-Content-Type-Options: nosniff
-  Referrer-Policy: same-origin
-  X-EveryResource: Gets this header
-  X-TransformedHeader: This is transformed
-/component---src-pages-404-tsx-70daa1be2219423f7f5e.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-index-tsx-38c0953b50340aa95cae.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/webpack-runtime-c41fe3b9106585da6a0d.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/framework-5e8a38bf990470ba1888.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
+# gatsby-adapter-netlify start
+/_gatsby/slices/_gatsby-scripts-1.html
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-media.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-sandbox-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-ww-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown-ww-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/debug/partytown.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/404.html/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/404/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/index/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/retiredpage/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/testpagenew/page-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/app/*
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-atomics.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-media.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown-sw.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/~partytown/partytown.js
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/page-data/app-data.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png/
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /app-c843bdf0e6663ec98280.js
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/static/*
-  Cache-Control: public, max-age=31536000, immutable
-  X-TransformedHeader: This is transformed
-/sw.js
-  Cache-Control: no-cache
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app-c843bdf0e6663ec98280.js.LICENSE.txt
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app-c843bdf0e6663ec98280.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/chunk-map.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-404-tsx-70daa1be2219423f7f5e.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-404-tsx-70daa1be2219423f7f5e.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-app-tsx-f3db3491e78f7def5ae9.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-index-tsx-38c0953b50340aa95cae.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-index-tsx-38c0953b50340aa95cae.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-retiredpage-tsx-be2d7a7f674cc173e4ad.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/component---src-pages-testpagenew-tsx-31b7db9d55bce8ea355c.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js.LICENSE.txt
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/framework-5e8a38bf990470ba1888.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/logo.png/
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack-runtime-c41fe3b9106585da6a0d.js
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack-runtime-c41fe3b9106585da6a0d.js.map
+  cache-control: public, max-age=31536000, immutable
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/webpack.stats.json
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
 /
-  X-PageName: Home
-  Link: <//blog../../../public/static/logo-6dca591e3658782c0d3e8dfc96c41b6e.png>; rel=preload; as=image
-  X-TransformedHeader: This is transformed 
-/blog/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/blog/404/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/blog/404.html
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/blog/app/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/blog/retiredpage/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
-/test-page
-  X-PageName: Test-Page
-  X-TransformedHeader: This is transformed
-/testpage
-  X-PageName: TestPage
-  X-TransformedHeader: This is transformed
-/blog/testpagenew/
-  X-PageSpecificHeader: This is a page
-  X-TransformedHeader: This is transformed
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/404/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/404.html
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/app/*
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/retiredpage/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+/testpagenew/
+  cache-control: public, max-age=0, must-revalidate
+  x-xss-protection: 1; mode=block
+  x-content-type-options: nosniff
+  referrer-policy: same-origin
+  x-frame-options: DENY
+
+# gatsby-adapter-netlify end

--- a/sanitized_redirects
+++ b/sanitized_redirects
@@ -1,12 +1,15 @@
 
-## Created with gatsby-plugin-netlify
+# gatsby-adapter-netlify start
 /testpageold/  /testpagenew/  302
 /permanentpageold/  /permanentpagenew/  301
-/retiredpage/  /  302!
-/forcepageold/  /forcepagenew/  302!
-/conditionspageold/  /conditionspagenew/  302  Language=en,fr  Country=us,ca
+/retiredpage/  /  302
+/forcepageold/  /forcepagenew/  302
+/conditionspageold/  /conditionspagenew/  302
 /redirectinbrowserpageold/  /redirectinbrowserpagenew/  302
 /statuscodepageold/  /statuscodepagenew/  303
 /ignoreCasePageOld  /ignorecAsepAgenEw/  302
-https://www.gatsbyjs.org  https://www.netlify.com  301!
-/app/*  /app/  200
+/https://www.gatsbyjs.org  https://www.netlify.com  301
+/app/*  /app/index.html  200
+/page-data/app/*  /page-data/app/page-data.json  200
+
+# gatsby-adapter-netlify end

--- a/sanitized_redirects_assetprefix
+++ b/sanitized_redirects_assetprefix
@@ -1,12 +1,15 @@
 
-## Created with gatsby-plugin-netlify
+# gatsby-adapter-netlify start
 /blog/testpageold/  /blog/testpagenew/  302
 /blog/permanentpageold/  /blog/permanentpagenew/  301
-/blog/retiredpage/  /blog/  302!
-/blog/forcepageold/  /blog/forcepagenew/  302!
-/blog/conditionspageold/  /blog/conditionspagenew/  302  Language=en,fr  Country=us,ca
+/blog/retiredpage/  /blog/  302
+/blog/forcepageold/  /blog/forcepagenew/  302
+/blog/conditionspageold/  /blog/conditionspagenew/  302
 /blog/redirectinbrowserpageold/  /blog/redirectinbrowserpagenew/  302
 /blog/statuscodepageold/  /blog/statuscodepagenew/  303
 /blog/ignoreCasePageOld  /blog/ignorecAsepAgenEw/  302
-https://www.gatsbyjs.org  https://www.netlify.com  301!
-/app/*  /app/  200
+/https://www.gatsbyjs.org  https://www.netlify.com  301
+/app/*  /app/index.html  200
+/page-data/app/*  /page-data/app/page-data.json  200
+
+# gatsby-adapter-netlify end

--- a/sanitized_redirects_extrapages
+++ b/sanitized_redirects_extrapages
@@ -1,12 +1,15 @@
 
-## Created with gatsby-plugin-netlify
+# gatsby-adapter-netlify start
 /testpageold/  /testpagenew/  302
 /permanentpageold/  /permanentpagenew/  301
-/retiredpage/  /  302!
-/forcepageold/  /forcepagenew/  302!
-/conditionspageold/  /conditionspagenew/  302  Language=en,fr  Country=us,ca
+/retiredpage/  /  302
+/forcepageold/  /forcepagenew/  302
+/conditionspageold/  /conditionspagenew/  302
 /redirectinbrowserpageold/  /redirectinbrowserpagenew/  302
 /statuscodepageold/  /statuscodepagenew/  303
 /ignoreCasePageOld  /ignorecAsepAgenEw/  302
-https://www.gatsbyjs.org  https://www.netlify.com  301!
-/app/*  /app/  200
+/https://www.gatsbyjs.org  https://www.netlify.com  301
+/app/*  /app/index.html  200
+/page-data/app/*  /page-data/app/page-data.json  200
+
+# gatsby-adapter-netlify end

--- a/sanitized_redirects_pathprefix
+++ b/sanitized_redirects_pathprefix
@@ -1,12 +1,15 @@
 
-## Created with gatsby-plugin-netlify
+# gatsby-adapter-netlify start
 /blog/testpageold/  /blog/testpagenew/  302
 /blog/permanentpageold/  /blog/permanentpagenew/  301
-/blog/retiredpage/  /blog/  302!
-/blog/forcepageold/  /blog/forcepagenew/  302!
-/blog/conditionspageold/  /blog/conditionspagenew/  302  Language=en,fr  Country=us,ca
+/blog/retiredpage/  /blog/  302
+/blog/forcepageold/  /blog/forcepagenew/  302
+/blog/conditionspageold/  /blog/conditionspagenew/  302
 /blog/redirectinbrowserpageold/  /blog/redirectinbrowserpagenew/  302
 /blog/statuscodepageold/  /blog/statuscodepagenew/  303
 /blog/ignoreCasePageOld  /blog/ignorecAsepAgenEw/  302
-https://www.gatsbyjs.org  https://www.netlify.com  301!
-/app/*  /app/  200
+/https://www.gatsbyjs.org  https://www.netlify.com  301
+/app/*  /app/index.html  200
+/page-data/app/*  /page-data/app/page-data.json  200
+
+# gatsby-adapter-netlify end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1541,6 +1541,27 @@
   resolved "https://registry.yarnpkg.com/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.2.tgz#0f164b726869f71da3c594171df5ebc1c4b0a407"
   integrity sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==
 
+"@netlify/cache-utils@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@netlify/cache-utils/-/cache-utils-5.1.5.tgz#848c59003e576fa0b2f9c6ca270eff27af938b25"
+  integrity sha512-lMNdFmy2Yu3oVquSPooRDLxJ8QOsIX6X6vzA2pKz/9V2LQFJiqBukggXM+Rnqzk1regPpdJ0jK3dPGvOKaRQgg==
+  dependencies:
+    cpy "^9.0.0"
+    get-stream "^6.0.0"
+    globby "^13.0.0"
+    junk "^4.0.0"
+    locate-path "^7.0.0"
+    move-file "^3.0.0"
+    path-exists "^5.0.0"
+    readdirp "^3.4.0"
+
+"@netlify/functions@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@netlify/functions/-/functions-1.6.0.tgz#c373423e6fef0e6f7422ac0345e8bbf2cb692366"
+  integrity sha512-6G92AlcpFrQG72XU8YH8pg94eDnq7+Q0YJhb8x4qNpdGsvuzvrfHWBmqFGp/Yshmv4wex9lpsTRZOocdrA2erQ==
+  dependencies:
+    is-promise "^4.0.0"
+
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
   version "5.1.1-v1"
   resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz#dbf733a965ca47b1973177dc0bb6c889edcfb129"
@@ -2569,6 +2590,14 @@ address@1.2.2, address@^1.0.1, address@^1.1.2:
   resolved "https://registry.yarnpkg.com/address/-/address-1.2.2.tgz#2b5248dac5485a6390532c6a517fda2e3faac89e"
   integrity sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==
 
+aggregate-error@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/aggregate-error/-/aggregate-error-4.0.1.tgz#25091fe1573b9e0be892aeda15c7c66a545f758e"
+  integrity sha512-0poP0T7el6Vq3rstR8Mn4V/IQrpBLO6POkUSrN7RhyY+GF/InCFShQzsQ39T25gkHhLgSLByyAz+Kjb+c2L98w==
+  dependencies:
+    clean-stack "^4.0.0"
+    indent-string "^5.0.0"
+
 ajv-keywords@^3.4.1, ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
@@ -2777,6 +2806,11 @@ arrify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-2.0.1.tgz#c9655e9331e0abcd588d2a7cad7e9956f66701fa"
   integrity sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
+
+arrify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/arrify/-/arrify-3.0.0.tgz#ccdefb8eaf2a1d2ab0da1ca2ce53118759fd46bc"
+  integrity sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==
 
 asap@~2.0.3:
   version "2.0.6"
@@ -3359,6 +3393,13 @@ ci-info@2.0.0, ci-info@^2.0.0:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
   integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
+clean-stack@^4.0.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-4.2.0.tgz#c464e4cde4ac789f4e0735c5d75beb49d7b30b31"
+  integrity sha512-LYv6XPxoyODi36Dp976riBtSY27VmFo+MKqEU9QCCWyTrdEPDog+RWA7xQWHi6Vbp61j5c4cdzzX1NidnwtUWg==
+  dependencies:
+    escape-string-regexp "5.0.0"
+
 cli-boxes@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.1.tgz#ddd5035d25094fce220e9cab40a45840a440318f"
@@ -3666,6 +3707,30 @@ cosmiconfig@^7.0.0:
     parse-json "^5.0.0"
     path-type "^4.0.0"
     yaml "^1.10.0"
+
+cp-file@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/cp-file/-/cp-file-9.1.0.tgz#e98e30db72d57d47b5b1d444deb70d05e5684921"
+  integrity sha512-3scnzFj/94eb7y4wyXRWwvzLFaQp87yyfTnChIjlfYrVqp5lVO3E2hIJMeQIltUT0K2ZAB3An1qXcBmwGyvuwA==
+  dependencies:
+    graceful-fs "^4.1.2"
+    make-dir "^3.0.0"
+    nested-error-stacks "^2.0.0"
+    p-event "^4.1.0"
+
+cpy@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/cpy/-/cpy-9.0.1.tgz#7f3ad0ad5bafe0bc70645c4bb567969927cadb9f"
+  integrity sha512-D9U0DR5FjTCN3oMTcFGktanHnAG5l020yvOCR1zKILmAyPP7I/9pl6NFgRbDcmSENtbK1sQLBz1p9HIOlroiNg==
+  dependencies:
+    arrify "^3.0.0"
+    cp-file "^9.1.0"
+    globby "^13.1.1"
+    junk "^4.0.0"
+    micromatch "^4.0.4"
+    nested-error-stacks "^2.1.0"
+    p-filter "^3.0.0"
+    p-map "^5.3.0"
 
 create-gatsby@^3.12.0:
   version "3.12.0"
@@ -4369,6 +4434,11 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
+escape-string-regexp@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz#4683126b500b61762f2dbebace1806e8be31b1c8"
+  integrity sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==
+
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
@@ -4746,7 +4816,7 @@ fast-fifo@^1.1.0, fast-fifo@^1.2.0:
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-glob@^3.2.9:
+fast-glob@^3.2.9, fast-glob@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
   integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
@@ -5048,6 +5118,17 @@ functions-have-names@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/functions-have-names/-/functions-have-names-1.2.3.tgz#0404fe4ee2ba2f607f0e0ec3c80bae994133b834"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
+
+gatsby-adapter-netlify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gatsby-adapter-netlify/-/gatsby-adapter-netlify-1.0.0.tgz#f984d92f5af690a33e300a0e8c7520ed9794c328"
+  integrity sha512-9dcKF2Xq5KV5R2QUcRjPFZS0gJ8efb+PSkc4cnsYz+hx1NOlAqXRN4h7hJAuQvaTAhjsaPfgs9r62d9g+JSyhQ==
+  dependencies:
+    "@babel/runtime" "^7.20.13"
+    "@netlify/cache-utils" "^5.1.5"
+    "@netlify/functions" "^1.6.0"
+    cookie "^0.5.0"
+    fs-extra "^11.1.1"
 
 gatsby-cli@^5.12.1:
   version "5.12.1"
@@ -5588,6 +5669,17 @@ globby@^11.0.3, globby@^11.0.4, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+globby@^13.0.0, globby@^13.1.1:
+  version "13.2.2"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-13.2.2.tgz#63b90b1bf68619c2135475cbd4e71e66aa090592"
+  integrity sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==
+  dependencies:
+    dir-glob "^3.0.1"
+    fast-glob "^3.3.0"
+    ignore "^5.2.4"
+    merge2 "^1.4.1"
+    slash "^4.0.0"
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -5833,7 +5925,7 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.2.0:
+ignore@^5.2.0, ignore@^5.2.4:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
@@ -5865,6 +5957,11 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+indent-string@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-5.0.0.tgz#4fd2980fccaf8622d14c64d694f4cf33c81951a5"
+  integrity sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -6116,6 +6213,11 @@ is-promise@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
+
+is-promise@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-4.0.0.tgz#42ff9f84206c1991d26debf520dd5c01042dd2f3"
+  integrity sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==
 
 is-regex@^1.1.4:
   version "1.1.4"
@@ -6408,6 +6510,11 @@ jsonfile@^6.0.1:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+junk@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/junk/-/junk-4.0.1.tgz#7ee31f876388c05177fe36529ee714b07b50fbed"
+  integrity sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==
+
 kebab-hash@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/kebab-hash/-/kebab-hash-0.1.2.tgz#dfb7949ba34d8e70114ea7d83e266e5e2a4abaac"
@@ -6562,6 +6669,13 @@ locate-path@^6.0.0:
   integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
   dependencies:
     p-locate "^5.0.0"
+
+locate-path@^7.0.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-7.2.0.tgz#69cb1779bd90b35ab1e771e1f2f89a202c2a8a8a"
+  integrity sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==
+  dependencies:
+    p-locate "^6.0.0"
 
 lock@^1.1.0:
   version "1.1.0"
@@ -6901,6 +7015,13 @@ moment@^2.29.4:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
 
+move-file@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/move-file/-/move-file-3.1.0.tgz#ea9675d54852708242462bfe60d56b3c3854cdf7"
+  integrity sha512-4aE3U7CCBWgrQlQDMq8da4woBWDGHioJFiOZ8Ie6Yq2uwYQ9V2kGhTz4x3u6Wc+OU17nw0yc3rJ/lQ4jIiPe3A==
+  dependencies:
+    path-exists "^5.0.0"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -6984,6 +7105,11 @@ neo-async@^2.6.1, neo-async@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz#26c8a3cee6cc05fbcf1e333cd2fc3e003326c0b5"
+  integrity sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==
 
 next-tick@1, next-tick@^1.1.0:
   version "1.1.0"
@@ -7286,6 +7412,20 @@ p-defer@^3.0.0:
   resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-3.0.0.tgz#d1dceb4ee9b2b604b1d94ffec83760175d4e6f83"
   integrity sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==
 
+p-event@^4.1.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/p-event/-/p-event-4.2.0.tgz#af4b049c8acd91ae81083ebd1e6f5cae2044c1b5"
+  integrity sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==
+  dependencies:
+    p-timeout "^3.1.0"
+
+p-filter@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-filter/-/p-filter-3.0.0.tgz#ce50e03b24b23930e11679ab8694bd09a2d7ed35"
+  integrity sha512-QtoWLjXAW++uTX67HZQz1dbTpqBfiidsB6VtQUC9iR85S120+s0T5sO6s+B5MLzFcZkrEd/DGMmCjR+f2Qpxwg==
+  dependencies:
+    p-map "^5.1.0"
+
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -7304,6 +7444,13 @@ p-limit@^2.0.0, p-limit@^2.2.0:
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
   dependencies:
     p-try "^2.0.0"
+
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
 
 p-locate@^3.0.0:
   version "3.0.0"
@@ -7325,6 +7472,27 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
+
+p-locate@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-6.0.0.tgz#3da9a49d4934b901089dca3302fa65dc5a05c04f"
+  integrity sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==
+  dependencies:
+    p-limit "^4.0.0"
+
+p-map@^5.1.0, p-map@^5.3.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/p-map/-/p-map-5.5.0.tgz#054ca8ca778dfa4cf3f8db6638ccb5b937266715"
+  integrity sha512-VFqfGDHlx87K66yZrNdI4YGtD70IRyd+zSvgks6mzHPRNkoKy+9EKP4SFC77/vTTQYmRmti7dvqC+m5jBrBAcg==
+  dependencies:
+    aggregate-error "^4.0.0"
+
+p-timeout@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
+  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
+  dependencies:
+    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -7427,6 +7595,11 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-exists@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-5.0.0.tgz#a6aad9489200b21fab31e49cf09277e5116fb9e7"
+  integrity sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"
@@ -8067,7 +8240,7 @@ readable-web-to-node-stream@^3.0.0:
   dependencies:
     readable-stream "^3.6.0"
 
-readdirp@~3.6.0:
+readdirp@^3.4.0, readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.6.0.tgz#74a370bd857116e245b29cc97340cd431a02a6c7"
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
@@ -8596,6 +8769,11 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slash@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
+  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
 slice-ansi@^4.0.0:
   version "4.0.0"
@@ -9713,6 +9891,11 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
 yoga-layout-prebuilt@^1.10.0:
   version "1.10.0"


### PR DESCRIPTION
Mimicks the behavior that a build would experience running on Netlify by explicitly setting the adapter config property to gatsby-adapter-netlify.

Sets the `headers` property in Gatsby config to as close as possible comparing to the previous `gatsby-plugin-netlify` configuration (it is not identical due to lack of support for allPageHeaders, transformHeaders, etc.).

When buliding on netlify, the process.env.NETLIFY evaluates to true so the gatsby-adapter-netlify adapter is used and the gatsby-plugin-netlify removed - there is no stock option to opt-out of the behavior.

Workarounds:

1. Stay on < 5.12.0
2. Implement a https://github.com/gatsbyjs/gatsby/discussions/38527#discussion-5604327 adapter